### PR TITLE
documentation consistency

### DIFF
--- a/controllers.go
+++ b/controllers.go
@@ -70,7 +70,7 @@ func GetRoutes(c echo.Context) error {
 	routes, err := getAllRoutes()
 	if err != nil {
 		Error.Println(err)
-		return err
+		return c.JSON(http.StatusInternalServerError, generateJSONError(err.Error()))
 	}
 
 	// fmt.Println("All routes in DB: ", routes)
@@ -86,7 +86,7 @@ func PostRoutes(c echo.Context) error {
 	err := c.Bind(&routes)
 	if err != nil {
 		Error.Println(err)
-		return err
+		return c.JSON(http.StatusInternalServerError, generateJSONError(err.Error()))
 	}
 
 	// fmt.Println("Registering routes: ", routes)
@@ -95,13 +95,13 @@ func PostRoutes(c echo.Context) error {
 		err = r.Create()
 		if err != nil {
 			Error.Println(err)
-			return err
+			return c.JSON(http.StatusInternalServerError, generateJSONError(err.Error()))
 		}
 	}
 
 	// fmt.Println("Registered AEACRoutes: ", routes, "to the database!")
 
-	return c.String(http.StatusOK, "AEACRoutes registered!")
+	return c.JSON(http.StatusOK, generateJSONMessage("AEACRoutes registered!"))
 }
 
 // endpoint we serve that returns the next route to be taken (the one with the lowest 'order' value)
@@ -113,7 +113,7 @@ func GetNextRoute(c echo.Context) error {
 	rows, err := querySelect(query)
 	if err != nil {
 		Error.Println(err)
-		return err
+		return c.JSON(http.StatusInternalServerError, generateJSONError(err.Error()))
 	}
 
 	var r AEACRoutes
@@ -123,7 +123,7 @@ func GetNextRoute(c echo.Context) error {
 			&r.MaxVehicleWeight, &r.Value, &r.Remarks, &r.Order)
 		if err != nil {
 			Error.Println(err)
-			return err
+			return c.JSON(http.StatusInternalServerError, generateJSONError(err.Error()))
 		}
 	}
 
@@ -131,7 +131,7 @@ func GetNextRoute(c echo.Context) error {
 	err = r.Delete()
 	if err != nil {
 		Error.Println(err)
-		return err
+		return c.JSON(http.StatusInternalServerError, generateJSONError(err.Error()))
 	}
 
 	// Warning.Println("Deleted route with ID: ", r.ID)
@@ -146,7 +146,7 @@ func LoadWaypoints (c echo.Context) error {
 	json_map := make(map[string]interface{})
 	err := json.NewDecoder(c.Request().Body).Decode(&json_map)
 	if err != nil {
-    	return err
+    	return c.JSON(http.StatusInternalServerError, generateJSONError(err.Error()))
 	} 
     
 	competition, ok := json_map["competition"]

--- a/controllers_test.go
+++ b/controllers_test.go
@@ -66,7 +66,13 @@ func TestPostWaypoints(t *testing.T) {
 
 	if assert.NoError(t, PostWaypoints(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "Waypoints successfully registered!", rec.Body.String())
+		successMsg := JSONResponse{
+			Type: "Message",
+			Message: "Waypoints successfully registered!",
+		}
+		var returnedMsg JSONResponse
+		json.Unmarshal([]byte(rec.Body.Bytes()), &returnedMsg)
+		assert.Equal(t, successMsg, returnedMsg)
 	}
 
 	cleanDB()
@@ -105,7 +111,13 @@ func TestGetWaypoints(t *testing.T) {
 
 	if assert.NoError(t, PostWaypoints(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "Waypoints successfully registered!", rec.Body.String())
+		successMsg := JSONResponse{
+			Type: "Message",
+			Message: "Waypoints successfully registered!",
+		}
+		var returnedMsg JSONResponse
+		json.Unmarshal([]byte(rec.Body.Bytes()), &returnedMsg)
+		assert.Equal(t, successMsg, returnedMsg)
 
 		//check if get returns all the waypoints
 
@@ -172,7 +184,13 @@ func TestPostRoutes(t *testing.T) {
 
 	if assert.NoError(t, PostRoutes(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "AEACRoutes registered!", rec.Body.String())
+		successMsg := JSONResponse{
+			Type: "Message",
+			Message: "AEACRoutes registered!",
+		}
+		var returnedMsg JSONResponse
+		json.Unmarshal([]byte(rec.Body.Bytes()), &returnedMsg)
+		assert.Equal(t, successMsg, returnedMsg)
 	}
 
 	cleanDB()
@@ -219,7 +237,13 @@ func TestGetRoutes(t *testing.T) {
 
 	if assert.NoError(t, PostRoutes(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "AEACRoutes registered!", rec.Body.String())
+		successMsg := JSONResponse{
+			Type: "Message",
+			Message: "AEACRoutes registered!",
+		}
+		var returnedMsg JSONResponse
+		json.Unmarshal([]byte(rec.Body.Bytes()), &returnedMsg)
+		assert.Equal(t, successMsg, returnedMsg)
 
 		//check if get returns all the routes
 
@@ -298,7 +322,13 @@ func TestGetNextRoute(t *testing.T) {
 
 	if assert.NoError(t, PostRoutes(c)) {
 		assert.Equal(t, http.StatusOK, rec.Code)
-		assert.Equal(t, "AEACRoutes registered!", rec.Body.String())
+		successMsg := JSONResponse{
+			Type: "Message",
+			Message: "AEACRoutes registered!",
+		}
+		var returnedMsg JSONResponse
+		json.Unmarshal([]byte(rec.Body.Bytes()), &returnedMsg)
+		assert.Equal(t, successMsg, returnedMsg)
 
 		//check that getNextRoute returns the route with the lowest order
 

--- a/types.go
+++ b/types.go
@@ -69,3 +69,8 @@ type RestrictedArea struct {
 	Bounds []Waypoint `json:"bounds"`
 	RejoinPoint Waypoint `json:"rejoin_at"`
 }
+
+type JSONResponse struct {
+	Type string `json:"type"`
+	Message string `json:"message"`
+}


### PR DESCRIPTION
Changed all error messages to return as a JSON so:

1. frontend can return what happened without having to switch to backend logs (if backend is running on a remote machine)
2. consistency before some were just plain text returns

Documentation created on Confluence https://ubcuas.atlassian.net/wiki/spaces/GCOM/pages/13238310/GCOM+Lite